### PR TITLE
Add retry interval command-line option

### DIFF
--- a/.goxc.json
+++ b/.goxc.json
@@ -4,7 +4,7 @@
 		"xc"
 	],
 	"BuildConstraints": "linux,amd64 windows,amd64 darwin,amd64",
-	"PackageVersion": "2.1.0",
+	"PackageVersion": "2.1.1",
 	"TaskSettings": {
 		"xc": {
 			"GOARM": "7"

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ Wait until an address become available.
 - `-address`: Address (e.g. http://google.com or tcp://mysql_ip:mysql_port) - *former **full-connection***
 - `-host`: Host to connect
 - `-port`: Port to connect (default 80)
-- `-timeout`: Time to wait until the address become available
+- `-timeout`: Seconds to wait until the address become available
+- `-retry`: Milliseconds to wait between retries
 - `-debug`: Enable debug
 - `-v`: Show the current version
 - `-file`: Path to the JSON file with the configs
@@ -34,7 +35,7 @@ waitforit -address=tcp://google.com:90 -timeout=20 -debug
 
 waitforit -address=http://google.com -timeout=20 -debug
 
-waitforit -address=http://google.com:90 -timeout=20 -debug
+waitforit -address=http://google.com:90 -timeout=20 -retry=500 -debug
 
 waitforit -address=http://google.com -timeout=20 -debug -- printf "Google Works\!"
 ```
@@ -50,7 +51,8 @@ Example JSON:
     {
       "host": "google.com",
       "port": 80,
-      "timeout": 20
+      "timeout": 20,
+      "retry": 500
     },
     {
       "address": "http://google.com:80",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 local:
-  image: golang:1.4.2
+  image: golang:1.9.2
   command: go run src/waitforit/main.go
   volumes:
     - .:/go/src/waitforit

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ type Config struct {
 	Port    int    `json:"port"`
 	Address string `json:"address"`
 	Timeout int    `json:"timeout"`
+	Retry   int    `json:"retry"`
 }
 
 // FileConfig describes the structure of the config json file
@@ -35,7 +36,8 @@ func main() {
 	address := flag.String("address", "", "address (e.g. http://google.com or tcp://mysql_ip:mysql_port)")
 	host := flag.String("host", "", "host to connect")
 	port := flag.Int("port", 80, "port to connect")
-	timeout := flag.Int("timeout", 10, "time to wait until the address become available")
+	timeout := flag.Int("timeout", 10, "seconds to wait until the address become available")
+	retry := flag.Int("retry", 500, "milliseconds to wait between retries")
 	printVersion := flag.Bool("v", false, "show the current version")
 	debug := flag.Bool("debug", false, "enable debug")
 	file := flag.String("file", "", "path of json file to read configs from")
@@ -73,6 +75,7 @@ func main() {
 					Port:    *port,
 					Address: *address,
 					Timeout: *timeout,
+					Retry:   *retry,
 				},
 			},
 		}

--- a/network_test.go
+++ b/network_test.go
@@ -126,6 +126,7 @@ func TestDialConn(t *testing.T) {
 	}
 
 	defaultTimeout := 5
+	defaultRetry := 500
 	for _, v := range testCases {
 		t.Run(v.title, func(t *testing.T) {
 			var err error
@@ -144,7 +145,7 @@ func TestDialConn(t *testing.T) {
 				}()
 			}
 
-			err = DialConn(&v.conn, defaultTimeout, print)
+			err = DialConn(&v.conn, defaultTimeout, defaultRetry, print)
 			if err != nil && v.finishOk {
 				t.Errorf("Expected to connect successfully %#v. But got error %v.", v.conn, err)
 				return

--- a/testdata/valid-config.json
+++ b/testdata/valid-config.json
@@ -8,6 +8,12 @@
     {
       "address": "http://google.com:80",
       "timeout": 40
+    },
+    {
+      "host": "yahoo.com",
+      "port": 8080,
+      "retry": 2000,
+      "timeout": 20
     }
   ]
 }


### PR DESCRIPTION
Previously you had to wait 500ms between retries.  Now you can specify that option with the `-retry` flag.